### PR TITLE
Dealing with non-ASCII contents etc.

### DIFF
--- a/splitter.py
+++ b/splitter.py
@@ -2,6 +2,9 @@
 from sgmllib import SGMLParser
 
 import codecs
+import sys
+reload(sys)
+sys.setdefaultencoding('utf8')
 
 class WikiParser(SGMLParser):
     """Parses a TiddlyWiki into individual tiddlers."""

--- a/splitter.py
+++ b/splitter.py
@@ -53,7 +53,8 @@ def main():
         os.makedirs(opts.dest)
 
     for t in parser.tiddlers:
-        fname = P.join(opts.dest, t["title"]) + ".txt"
+        title_fixed = re.sub("[/><]", "", t["title"]) # 從 title 中去除 / > < 等字元，給下一行用
+        fname = P.join(opts.dest, title_fixed) + ".txt"
         fout = codecs.open(fname, "w", "utf-8")
         title, text, tags = t["title"], t["text"], t["tags"]
         if opts.vim_notes:

--- a/splitter.py
+++ b/splitter.py
@@ -3,6 +3,7 @@ from sgmllib import SGMLParser
 
 import codecs
 import sys
+import re
 reload(sys)
 sys.setdefaultencoding('utf8')
 

--- a/splitter.py
+++ b/splitter.py
@@ -53,7 +53,7 @@ def main():
         os.makedirs(opts.dest)
 
     for t in parser.tiddlers:
-        title_fixed = re.sub("[/><]", "", t["title"]) # 從 title 中去除 / > < 等字元，給下一行用
+        title_fixed = re.sub("[/><]", "", t["title"]) # Remove "/ > <" characters from title, for use in the next line
         fname = P.join(opts.dest, title_fixed) + ".txt"
         fout = codecs.open(fname, "w", "utf-8")
         title, text, tags = t["title"], t["text"], t["tags"]


### PR DESCRIPTION
Hi @mpenkov ,

Thank you so much for your useful script dated back 7 years ago, which really still help me even now.

Since my first language is Mandarin/Chinese, I have encountered errors processing my TiddlyWiki file (with a lot of non-ASCII characters of course), like
```
Traceback (most recent call last):
  File "splitter.py", line 65, in <module>
    sys.exit(main())
  File "splitter.py", line 59, in main
    fout.write("\n".join([title] + text + ["tags: " + tags ]))
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/codecs.py", line 694, in write
    return self.writer.write(data)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/codecs.py", line 357, in write
    data, consumed = self.encode(object, self.errors)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe5 in position 3: ordinal not in range(128)
```

Also, some of my tiddler titles contain `/ > < `, therefore I can also get
```
    file = __builtin__.open(filename, mode, buffering)
IOError: [Errno 2] No such file or directory: '../TiddlySpace/gjrobert-info/20110422\xef\xbc\x9a\xe6\x89\x8b\xe6\xa9\x9f\xe9\x81\xad\xe5\x88\xb0\xe6\x93\x8a\xe6\x89\x93 >///<.txt'
```

So, I'm dealing these two issues with my ugly and amateur additions.